### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    
+    permissions:
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/ankit-roy-0602/postman-mcp-server/security/code-scanning/10](https://github.com/ankit-roy-0602/postman-mcp-server/security/code-scanning/10)

To fix the issue, we will add a `permissions` block to the `docker` job in the workflow file. This block will explicitly set the permissions required for the job. Since the `docker` job primarily interacts with Docker Hub and does not appear to require write access to the repository, we will set `contents: read` as the minimal permission. This ensures that the job has only the access it needs and nothing more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
